### PR TITLE
Adding a map which can be sealed/unsealed for writes on demand

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMetadataQuery.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexTableInputRef.RelTableRef;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.SealableMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -35,9 +36,9 @@ import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
 
 /**
  * RelMetadataQuery provides a strongly-typed facade on top of
@@ -75,8 +76,17 @@ import java.util.Set;
  * plugin mechanism.
  */
 public class RelMetadataQuery {
-  /** Set of active metadata queries, and cache of previous results. */
-  public final Map<List, Object> map = new HashMap<>();
+  /**
+   * Set of active metadata queries, and cache of previous results.
+   *
+   * Can be sealed when no more additions to the map are expected.
+   * Write operations on the map will fail after sealing
+   *
+   * Sealing is helpful if no additions to the map are expected or desired.
+   * The map here is unbounded so it can leak memory if not properly cleaned
+   * up
+   */
+  public final SealableMap<List, Object> map = new SealableMap<>(new HashMap<>());
 
   public final JaninoRelMetadataProvider metadataProvider;
 

--- a/core/src/main/java/org/apache/calcite/util/SealableMap.java
+++ b/core/src/main/java/org/apache/calcite/util/SealableMap.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+
+/**
+ * This implementation of {@link Map} can be sealed and unsealed at will. When
+ * sealed, it does not accept any writes.
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ */
+public class SealableMap<K, V> implements Map<K, V> {
+  //~ Instance fields --------------------------------------------------------
+
+  private final Map<K, V> delegate;
+  private final Map<K, V> readOnlyDelegate;
+  private boolean sealed = false;
+
+  //~ Constructors -----------------------------------------------------------
+
+  /**
+   * Creates a map that can be sealed and unsealed at will. When sealed, the
+   * map will not accept any write operations
+   * @param delegate the map that all calls will be delegated to. Will not
+   *                 delegate write calls when sealed. Any changes
+   *                 to the delegate will reflect in the {@link SealableMap}
+   */
+  public SealableMap(Map<K, V> delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "Delegate map cannot be null");
+    this.readOnlyDelegate = Collections.unmodifiableMap(delegate);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public int size() {
+    return delegate.size();
+  }
+
+  @Override public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override public boolean containsKey(Object key) {
+    return delegate.containsKey(key);
+  }
+
+  @Override public boolean containsValue(Object value) {
+    return delegate.containsValue(value);
+  }
+
+  @Override public V get(Object key) {
+    return delegate.get(key);
+  }
+
+  @Override public V put(K key, V value) {
+    checkSealed();
+    return delegate.put(key, value);
+  }
+
+  @Override public V remove(Object key) {
+    checkSealed();
+    return delegate.remove(key);
+  }
+
+  @Override public void putAll(Map<? extends K, ? extends V> m) {
+    checkSealed();
+    delegate.putAll(m);
+  }
+
+  @Override public void clear() {
+    checkSealed();
+    delegate.clear();
+  }
+
+  @Override public Set<K> keySet() {
+    return sealed ? readOnlyDelegate.keySet() : delegate.keySet();
+  }
+
+  @Override public Collection<V> values() {
+    return sealed ? readOnlyDelegate.values() : delegate.values();
+  }
+
+  @Override public Set<Entry<K, V>> entrySet() {
+    return sealed ? readOnlyDelegate.entrySet() : delegate.entrySet();
+  }
+
+  @Override public V getOrDefault(Object key, V defaultValue) {
+    return delegate.getOrDefault(key, defaultValue);
+  }
+
+  @Override public void forEach(BiConsumer<? super K, ? super V> action) {
+    delegate.forEach(action);
+  }
+
+  @Override public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+    checkSealed();
+    delegate.replaceAll(function);
+  }
+
+  @Override public V putIfAbsent(K key, V value) {
+    checkSealed();
+    return delegate.putIfAbsent(key, value);
+  }
+
+  @Override public boolean remove(Object key, Object value) {
+    checkSealed();
+    return delegate.remove(key, value);
+  }
+
+  @Override public boolean replace(K key, V oldValue, V newValue) {
+    checkSealed();
+    return delegate.replace(key, oldValue, newValue);
+  }
+
+  @Override public V replace(K key, V value) {
+    checkSealed();
+    return delegate.replace(key, value);
+  }
+
+  @Override public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+    checkSealed();
+    return delegate.computeIfAbsent(key, mappingFunction);
+  }
+
+  @Override public V computeIfPresent(
+      K key,
+      BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    checkSealed();
+    return delegate.computeIfPresent(key, remappingFunction);
+  }
+
+  @Override public V compute(
+      K key,
+      BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    checkSealed();
+    return delegate.compute(key, remappingFunction);
+  }
+
+  @Override public V merge(
+      K key,
+      V value,
+      BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+    checkSealed();
+    return delegate.merge(key, value, remappingFunction);
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SealableMap)) {
+      return false;
+    }
+    SealableMap<?, ?> that = (SealableMap<?, ?>) o;
+    return sealed == that.sealed && delegate.equals(that.delegate);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(delegate, sealed);
+  }
+
+  @Override public String toString() {
+    return "SealableMap{" + "delegate=" + delegate + ", sealed=" + sealed + '}';
+  }
+
+  /**
+   * Seals the map for writes. No effect if already sealed
+   */
+  public void seal() {
+    sealed = true;
+  }
+
+  /**
+   * Unseals the map for writes. No effect if already unsealed
+   */
+  public void unseal() {
+    sealed = false;
+  }
+
+  /**
+   * @return if the map is currently sealed
+   */
+  public boolean isSealed() {
+    return sealed;
+  }
+
+  private void checkSealed() {
+    if (sealed) {
+      throw new IllegalStateException("Cannot write to this map when it is sealed");
+    }
+  }
+}
+
+// End SealableMap.java

--- a/core/src/main/java/org/apache/calcite/util/SealableMap.java
+++ b/core/src/main/java/org/apache/calcite/util/SealableMap.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.util;
 
 import com.google.common.collect.ForwardingMap;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public class SealableMap<K, V> extends ForwardingMap<K, V> {
 
   //~ Methods ----------------------------------------------------------------
 
-  // SealableMap public methods
+  //~ SealableMap public methods -------------------------------------------
 
   /**
    * Seals the map for writes. No effect if already sealed
@@ -78,14 +79,13 @@ public class SealableMap<K, V> extends ForwardingMap<K, V> {
     return sealed;
   }
 
-  // Implemented for ForwardingMap
+  //~ Methods implemented for ForwardingMap -------------------------------------------
 
-  @Override
-  protected Map<K, V> delegate() {
+  @Override protected Map<K, V> delegate() {
     return sealed ? readOnlyDelegate : delegate;
   }
 
-  // overridden from ForwardingMap
+  //~ Methods overridden from ForwardingMap -------------------------------------------
 
   @Override public boolean equals(Object o) {
     if (this == o) {
@@ -106,7 +106,7 @@ public class SealableMap<K, V> extends ForwardingMap<K, V> {
     return "SealableMap{" + "delegate=" + delegate + ", sealed=" + sealed + '}';
   }
 
-  // Overridden from Map
+  //~ Methods overridden from Map -------------------------------------------
 
   @Override public V getOrDefault(Object key, V defaultValue) {
     return delegate.getOrDefault(key, defaultValue);
@@ -168,7 +168,7 @@ public class SealableMap<K, V> extends ForwardingMap<K, V> {
     return delegate.merge(key, value, remappingFunction);
   }
 
-  // SealableMap private methods
+  //~ SealableMap private methods -------------------------------------------
 
   private void checkSealed() {
     if (sealed) {

--- a/core/src/test/java/org/apache/calcite/util/SealableMapTest.java
+++ b/core/src/test/java/org/apache/calcite/util/SealableMapTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the seal/unseal functionalities of {@link SealableMap}
+ */
+public class SealableMapTest {
+  //~ Constructors -----------------------------------------------------------
+
+  public SealableMapTest() {
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Test public void testSealUnseal() {
+    Map<String, String> backingMap = new HashMap<>();
+    SealableMap<String, String> sealableMap = new SealableMap<>(backingMap);
+    sealableMap.put("foo1", "bar1");
+    sealableMap.put("foo2", "bar2");
+
+    // start off unsealed
+    ensureUnsealed(sealableMap, backingMap);
+
+    // seal and verify
+    sealableMap.seal();
+    ensureSealed(sealableMap, backingMap);
+
+    // unseal and verify
+    sealableMap.unseal();
+    ensureUnsealed(sealableMap, backingMap);
+  }
+
+  @Test public void testEqualsHashCode() {
+    Map<String, String> backingMap = new HashMap<>();
+    backingMap.put("foo", "bar");
+
+    // will be equal
+    SealableMap<String, String> map1 = new SealableMap<>(backingMap);
+    SealableMap<String, String> map2 = new SealableMap<>(backingMap);
+
+    // will be unequal because this map will be sealed
+    SealableMap<String, String> map3 = new SealableMap<>(backingMap);
+    map3.seal();
+
+    // will be unequal because map entries are different
+    SealableMap<String, String> map4 = new SealableMap<>(new HashMap<>());
+    map4.put("foo", "baz");
+
+    assertEquals(map1, map2);
+    assertEquals(map1.hashCode(), map2.hashCode());
+
+    assertNotEquals(map1, map3);
+    assertNotEquals(map1, map4);
+  }
+
+  private void ensureSealed(SealableMap<String, String> map, Map<String, String> backingMap) {
+    assertTrue(map.isSealed());
+    ensureReadable(map, backingMap);
+
+    ensureFailure(() -> {
+      map.put("foo", "bar");
+      return "put";
+    });
+
+    ensureFailure(() -> {
+      map.remove("foo");
+      return "remove(k)";
+    });
+
+    ensureFailure(() -> {
+      map.putAll(backingMap);
+      return "putAll";
+    });
+
+    ensureFailure(() -> {
+      map.clear();
+      return "clear";
+    });
+
+    ensureFailure(() -> {
+      map.keySet().clear();
+      return "keySet mutate";
+    });
+
+    ensureFailure(() -> {
+      map.values().clear();
+      return "values mutate";
+    });
+
+    ensureFailure(() -> {
+      map.entrySet().clear();
+      return "entrySet mutate";
+    });
+
+    ensureFailure(() -> {
+      map.replaceAll((k, v) -> v);
+      return "replaceAll";
+    });
+
+    ensureFailure(() -> {
+      map.putIfAbsent("foo", "bar");
+      return "putIfAbsent";
+    });
+
+    ensureFailure(() -> {
+      map.remove("foo", "bar");
+      return "remove(k,v)";
+    });
+
+    ensureFailure(() -> {
+      map.replace("foo", "bar", "baz");
+      return "replace(k,o_v,n_v)";
+    });
+
+    ensureFailure(() -> {
+      map.replace("foo", "baz");
+      return "replace(k,n_v)";
+    });
+
+    ensureFailure(() -> {
+      map.computeIfAbsent("foo", ignored -> "bar");
+      return "computeIfAbsent";
+    });
+
+    ensureFailure(() -> {
+      map.computeIfPresent("foo", (ignored1, ignored2) -> "bar");
+      return "computeIfPresent";
+    });
+
+    ensureFailure(() -> {
+      map.compute("foo", (ignored1, ignored2) -> "bar");
+      return "compute";
+    });
+
+    ensureFailure(() -> {
+      map.merge("foo", "bar", (ignored1, ignored2) -> "baz");
+      return "merge";
+    });
+  }
+
+  private void ensureUnsealed(SealableMap<String, String> map, Map<String, String> backingMap) {
+    assertFalse(map.isSealed());
+    ensureReadable(map, backingMap);
+
+    Map<String, String> backingMapCopy = new HashMap<>(backingMap);
+
+    String key = "@@key@@";
+    String value1 = "@@value1@@";
+    String value2 = "@@value2@@";
+
+    map.put(key, value1);
+    assertEquals(map.get(key), value1);
+    map.remove(key);
+    assertFalse(map.containsKey(key));
+
+    map.clear();
+    map.putAll(backingMapCopy);
+    assertEquals(map.entrySet(), backingMapCopy.entrySet());
+
+    map.keySet().clear();
+    map.putAll(backingMapCopy);
+
+    map.values().clear();
+    map.putAll(backingMapCopy);
+
+    map.entrySet().clear();
+    map.putAll(backingMapCopy);
+
+    map.replaceAll((k, v) -> value1);
+    map.values().forEach(value -> assertEquals(value, value1));
+    map.clear();
+    map.putAll(backingMapCopy);
+
+    map.putIfAbsent(key, value1);
+    assertEquals(map.get(key), value1);
+    map.replace(key, value1, value2);
+    assertEquals(map.get(key), value2);
+    map.replace(key, value1);
+    assertEquals(map.get(key), value1);
+    map.remove(key, value1);
+    assertFalse(map.containsKey(key));
+
+    map.computeIfAbsent(key, k -> value1);
+    assertEquals(map.get(key), value1);
+    map.computeIfPresent(key, (k, v) -> value2);
+    assertEquals(map.get(key), value2);
+    map.compute(key, (k, v) -> value1);
+    assertEquals(map.get(key), value1);
+    map.merge(key, value1, (k, v) -> null);
+    assertFalse(map.containsKey(key));
+
+    // clean up
+    map.clear();
+    map.putAll(backingMapCopy);
+  }
+
+  private <K, V> void ensureReadable(Map<K, V> map, Map<K, V> backingMap) {
+    assertEquals(map.size(), backingMap.size());
+    assertEquals(map.isEmpty(), backingMap.isEmpty());
+    assertEquals(map.entrySet(), backingMap.entrySet());
+
+    backingMap.forEach((k, v) -> {
+      assertTrue(map.containsKey(k));
+      assertTrue(map.containsValue(v));
+      assertEquals(map.get(k), v);
+      assertEquals(map.getOrDefault(k, null), v);
+    });
+  }
+
+  private void ensureFailure(Supplier<String> work) {
+    try {
+      String opName = work.get();
+      fail(opName + " is expected to fail");
+    } catch (IllegalStateException | UnsupportedOperationException e) {
+      // expected. Nothing to do
+    }
+  }
+}
+
+// End SealableMapTest.java

--- a/core/src/test/java/org/apache/calcite/util/SealableMapTest.java
+++ b/core/src/test/java/org/apache/calcite/util/SealableMapTest.java
@@ -78,11 +78,12 @@ public class SealableMapTest {
 
     assertNotEquals(map1, map3);
     assertNotEquals(map1, map4);
+    assertNotEquals(map3, map4);
   }
 
   private void ensureSealed(SealableMap<String, String> map, Map<String, String> backingMap) {
     assertTrue(map.isSealed());
-    ensureReadable(map, backingMap);
+    ensureReadableAndDataMatchesDelegate(map, backingMap);
 
     ensureFailure(() -> {
       map.put("foo", "bar");
@@ -167,7 +168,7 @@ public class SealableMapTest {
 
   private void ensureUnsealed(SealableMap<String, String> map, Map<String, String> backingMap) {
     assertFalse(map.isSealed());
-    ensureReadable(map, backingMap);
+    ensureReadableAndDataMatchesDelegate(map, backingMap);
 
     Map<String, String> backingMapCopy = new HashMap<>(backingMap);
 
@@ -221,7 +222,7 @@ public class SealableMapTest {
     map.putAll(backingMapCopy);
   }
 
-  private <K, V> void ensureReadable(Map<K, V> map, Map<K, V> backingMap) {
+  private <K, V> void ensureReadableAndDataMatchesDelegate(Map<K, V> map, Map<K, V> backingMap) {
     assertEquals(map.size(), backingMap.size());
     assertEquals(map.isEmpty(), backingMap.isEmpty());
     assertEquals(map.entrySet(), backingMap.entrySet());


### PR DESCRIPTION
The new map is used in `RelMetadataQuery` which contains an unbound map to which
entries are added conditionally when a new `RelNode` is created on the cluster.

`RelMetadataQuery` is used in `RelOptCluster`. For `RelOptCluster`s that are long
lived, this can result in memory leaks when `RelNode`s are added to the map and
that is the only remaining reference to the `RelNode` preventing garbage
collection

`RelMetadataQuery` is not thread-safe so its map cannot be written to if it is
used across multiple threads. Instead, its map should be sealed before using
in it in a multi threaded environment.

There is no change from current behavior if the seal/unseal functionality is
not used

As an example, consider the following setup
```
void example() {
  RelBuilder relBuilder = RelBuilder.create(frameworkConfig);
  LogicalProject longLivedProject = (LogicalProject) relBuilder.scan("Foo").project(relBuilder.field("a")).build();
  // at this point there is one entry in the  RelMetadataQuery#map (longLivedProject)
  LogicalProject shortLivedProject = createProjectUsingTemplate_bad(project);
  // there are now two entries in the map (longLivedProject, shortLivedProject)
  LogicalProject anotherShortLivedProject = createProjectUsingTemplate_good(project);
  // there are still two entries in the map (longLivedProject, shortLivedProject)
  shortLivedProject = null;
  anotherShortLivedProject = null;
  // anotherShortLivedProject can get garbage collected because there are no references to it but shortLivedProject won't 
  // because the map still has a reference to it (a leak !)
}

LogicalProject createProjectUsingTemplate_bad(LogicalProject project) {
  return LogicalProject.create(project.getInput(), project.getProjects(), project.getRowType());
}
 
LogicalProject createProjectUsingTemplate_good(LogicalProject project) {
  return LogicalProject.copy(project.getTraitSet(), project.getInput(),, project.getProjects(), project.getRowType());
}
```
While the good and bad versions can be "best practices" and caught through code reviews, that sort of process is error prone. It would be better if there was a programmatic way of making sure there are no leaks. This PR helps detect leaks of this kind (not fix them). With the changes in this PR, here is how `example()` would be written

```
void example() {
  RelBuilder relBuilder = RelBuilder.create(frameworkConfig);
  LogicalProject longLivedProject = (LogicalProject) relBuilder.scan("Foo").project(relBuilder.field("a")).build();
  longLivedProject.getCluster().getRelMetadataQuery().map.seal();
  // the next line will throw because an addition to the map is not possible. Which will tell us during the development process
  // that the function has to be rewritten or a different strategy used; a common fallback strategy is to use another RelBuilder
  // and copy the whole AST. That way the clusters (and metadata queries) get separated.
  LogicalProject shortLivedProject = createProjectUsingTemplate_bad(project); // will throw
}
```