### PR TITLE
Add additional shading rules in calcite-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -456,6 +456,18 @@ limitations under the License.
                   <pattern>org.pentaho</pattern>
                   <shadedPattern>com.linkedin.coral.org.pentaho</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.codec</pattern>
+                  <shadedPattern>com.linkedin.coral.org.apache.commons.codec</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.logging</pattern>
+                  <shadedPattern>com.linkedin.coral.org.apache.commons.logging</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>com.linkedin.coral.javax.annotation</shadedPattern>
+                </relocation>
               </relocations>
               <filters>
                 <filter>


### PR DESCRIPTION
When integrating Coral/Calcite with Presto, the listed jars are not shaded properly and conflicts with ones Presto brings in. After applying these additional shading rules, it integrating well with Presto by building and running tests.