### PR TITLE
fix headings for javadoc

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTrait.java
@@ -21,7 +21,7 @@ package org.apache.calcite.plan;
  * a trait definition. For example, a {@code CallingConvention.JAVA} is a trait
  * of the {@link ConventionTraitDef} trait definition.
  *
- * <h3><a id="EqualsHashCodeNote">Note about equals() and hashCode()</a></h3>
+ * <h2><a id="EqualsHashCodeNote">Note about equals() and hashCode()</a></h2>
  *
  * <p>If all instances of RelTrait for a particular RelTraitDef are defined in
  * an {@code enum} and no new RelTraits can be introduced at runtime, you need

--- a/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/IntersectToDistinctRule.java
@@ -41,7 +41,7 @@ import java.math.BigDecimal;
  *
  * <p> Rewrite: (GB-Union All-GB)-GB-UDTF (on all attributes)
  *
- * <h3>Example</h3>
+ * <h2>Example</h2>
  *
  * <p>Query: <code>R1 Intersect All R2</code>
  *

--- a/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlJdbcFunctionCall.java
@@ -50,7 +50,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
  * <tr>
  * <td colspan="2"><br>
  *
- * <h3>NUMERIC FUNCTIONS</h3>
+ * <h2>NUMERIC FUNCTIONS</h2>
  * </td>
  * </tr>
  * <tr>

--- a/core/src/main/java/org/apache/calcite/sql/validate/SelectScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SelectScope.java
@@ -48,7 +48,7 @@ import java.util.List;
  * {@link SqlValidatorNamespace} when resolving 'name', and
  * as a {@link SqlValidatorScope} when resolving 'gender'.</p>
  *
- * <h3>Scopes</h3>
+ * <h2>Scopes</h2>
  *
  * <p>In the query</p>
  *

--- a/core/src/main/java/org/apache/calcite/util/Static.java
+++ b/core/src/main/java/org/apache/calcite/util/Static.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * Definitions of objects to be statically imported.
  *
- * <h3>Note to developers</h3>
+ * <h2>Note to developers</h2>
  *
  * <p>Please give careful consideration before including an object in this
  * class. Pros:

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -988,7 +988,7 @@ public class Util {
    *
    * <p>but the usual usage is to pass in a descriptive string.
    *
-   * <h3>Examples</h3>
+   * <h4>Examples</h4>
    *
    * <h4>Example #1: Using <code>deprecated</code> to fail if a piece of
    * supposedly dead code is reached</h4>

--- a/core/src/main/java/org/apache/calcite/util/trace/CalciteTrace.java
+++ b/core/src/main/java/org/apache/calcite/util/trace/CalciteTrace.java
@@ -31,7 +31,7 @@ import java.io.File;
  * Contains all of the {@link org.slf4j.Logger tracers} used within
  * org.apache.calcite class libraries.
  *
- * <h3>Note to developers</h3>
+ * <h2>Note to developers</h2>
  *
  * <p>Please ensure that every tracer used in org.apache.calcite is added to
  * this class as a <em>public static final</em> member called <code>

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Enumerator.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Enumerator.java
@@ -106,7 +106,7 @@ public interface Enumerator<T> extends AutoCloseable {
    * <p>This method is optional; it may throw
    * {@link UnsupportedOperationException}.
    *
-   * <h3>Notes to Implementers</h3>
+   * <h4>Notes to Implementers</h4>
    *
    * <p>All calls to Reset must result in the same state for the enumerator.
    * The preferred implementation is to move the enumerator to the beginning

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Extensions.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Extensions.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * Contains what, in LINQ.NET, would be extension methods.
  *
- * <h3>Notes on mapping from LINQ.NET to Java</h3>
+ * <h2>Notes on mapping from LINQ.NET to Java</h2>
  *
  * <p>We have preserved most of the API. But we've changed a few things, so that
  * the API is more typical Java API:</p>


### PR DESCRIPTION
When tried to generate javadoc, an error has occurred in Javadoc report generation:
[ERROR] Exit code: 1 - /Users/ychen6/open/linkedin-calcite/core/src/main/java/org/apache/calcite/util/Static.java:28: error: heading used out of sequence: < H3>, compared to implicit preceding heading: < H1>
[ERROR]  * < h3 >Note to developers</ h3 >
[ERROR]    ^

Update the heading usage so that it meets javadoc requirement.
