### PR TITLE
Verify if schema is null before using schema.getSubSchema

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -975,6 +975,9 @@ public class SqlValidatorUtil {
           && SqlNameMatchers.withCaseSensitive(true).matches(p, schema.getName())) {
         continue;
       }
+      if (schema == null) {
+        break;
+      }
       schema = schema.getSubSchema(p, true);
     }
     return schema == null ? null : schema.getType(name, false);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -971,12 +971,12 @@ public class SqlValidatorUtil {
     }
     CalciteSchema schema = rootSchema;
     for (String p : path) {
+      if (schema == null) {
+        break;
+      }
       if (schema == rootSchema
           && SqlNameMatchers.withCaseSensitive(true).matches(p, schema.getName())) {
         continue;
-      }
-      if (schema == null) {
-        break;
       }
       schema = schema.getSubSchema(p, true);
     }


### PR DESCRIPTION
If `schema` becomes `null` in the loop, there will be a null pointer exception while calling `schema = schema.getSubSchema(p, true);`
which will cause the exception while translating some production views with Coral:
```
java.lang.NullPointerException
        at org.apache.calcite.sql.validate.SqlValidatorUtil.getTypeEntry(SqlValidatorUtil.java:978)
        at org.apache.calcite.prepare.CalciteCatalogReader.getNamedType(CalciteCatalogReader.java:174)
        at org.apache.calcite.sql.validate.SqlValidatorImpl.getValidatedNodeTypeIfKnown(SqlValidatorImpl.java:1609)
        ...
```
This patch adds the verification before calling `schema = schema.getSubSchema(p, true);`

Tested on the affected production views, which could be translated well with this patch