### PR TITLE
Upgrade jackson-databind to 2.9.10.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ limitations under the License.
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
     <hydromatic-tpcds.version>0.4</hydromatic-tpcds.version>
     <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.10.7</jackson-databind.version>
+    <jackson-databind.version>2.9.10.8</jackson-databind.version>
     <janino.version>3.0.11</janino.version>
     <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     <java-diff.version>1.1.2</java-diff.version>


### PR DESCRIPTION
If the version is 2.9.10.7, it fails to be ELRed:
```
Notes: Vulnerability found and is blocked by oss-canary: vulnerability: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource. remediation: Upgrade to version com.fasterxml.jackson.core:jackson-databind:2.9.10.8...
```