### PR TITLE
Add support for MAP in SqlTypeAssignmentRules

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeAssignmentRules.java
@@ -193,6 +193,9 @@ public class SqlTypeAssignmentRules {
     // ARRAY is assignable from ...
     rules.add(SqlTypeName.ARRAY, EnumSet.of(SqlTypeName.ARRAY));
 
+    // MAP is assignable from ...
+    rules.add(SqlTypeName.MAP, EnumSet.of(SqlTypeName.MAP));
+
     // ANY is assignable from ...
     rule.clear();
     rule.add(SqlTypeName.TINYINT);


### PR DESCRIPTION
Add `MAP` support in `SqlTypeAssignmentRules` so that `MAP` type could be unionized, which can help avoid this exception:
```
Exception in thread "main" java.lang.AssertionError: No assign rules for MAP defined
        at org.apache.calcite.sql.type.SqlTypeAssignmentRules.canCastFrom(SqlTypeAssignmentRules.java:427)
        at org.apache.calcite.sql.type.SqlTypeUtil.canCastFrom(SqlTypeUtil.java:911)
        at org.apache.calcite.sql.type.SqlTypeUtil.canCastFrom(SqlTypeUtil.java:857)
        at org.apache.calcite.sql.type.SqlTypeUtil.canCastFrom(SqlTypeUtil.java:888)
```

Tested on affected production views, which could be translated well.