### PR TITLE
Allows user to use `SELECT ARRAY[]`

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlArrayValueConstructor.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlArrayValueConstructor.java
@@ -17,9 +17,14 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+
+import java.util.List;
 
 /**
  * Definition of the SQL:2003 standard ARRAY constructor, <code>ARRAY
@@ -40,6 +45,27 @@ public class SqlArrayValueConstructor extends SqlMultisetValueConstructor {
     }
     return SqlTypeUtil.createArrayType(
         opBinding.getTypeFactory(), type, false);
+  }
+
+  /**
+   * Allow users to select an empty array
+   */
+  public static class SqlArrayValueConstructorAllowingEmpty
+      extends SqlArrayValueConstructor {
+    @Override protected RelDataType getComponentType(
+        RelDataTypeFactory typeFactory, List<RelDataType> argTypes) {
+      if (argTypes.isEmpty()) {
+        return typeFactory.createSqlType(SqlTypeName.NULL);
+      }
+      return super.getComponentType(typeFactory, argTypes);
+    }
+
+    @Override public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+      if (callBinding.operands().isEmpty()) {
+        return true;
+      }
+      return super.checkOperandTypes(callBinding, throwOnFailure);
+    }
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -2035,7 +2035,7 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    * The ARRAY Value Constructor. e.g. "<code>ARRAY[1, 2, 3]</code>".
    */
   public static final SqlArrayValueConstructor ARRAY_VALUE_CONSTRUCTOR =
-      new SqlArrayValueConstructor();
+      new SqlArrayValueConstructor.SqlArrayValueConstructorAllowingEmpty();
 
   /**
    * The MAP Value Constructor,

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -7482,11 +7482,6 @@ public abstract class SqlOperatorBaseTest {
         "Array['foo', 'bar']",
         "[foo, bar]",
         "CHAR(3) NOT NULL ARRAY NOT NULL");
-
-    // empty array is illegal per SQL spec. presumably because one can't
-    // infer type
-    tester.checkFails(
-        "^Array[]^", "Require at least 1 argument", false);
   }
 
   @Test public void testItemOp() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.calcite.sql.test;
 
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.test.SqlValidatorTestCase;
+
+import org.junit.Test;
+
 
 /**
  * Concrete subclass of {@link SqlOperatorBaseTest} which checks against
@@ -32,6 +36,12 @@ public class SqlOperatorTest extends SqlOperatorBaseTest {
    */
   public SqlOperatorTest() {
     super(false, DEFAULT_TESTER);
+  }
+
+  @Test
+  public void testEmptyArray() {
+    tester.setFor(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR);
+    tester.checkScalar("Array[]", "[]", "NULL ARRAY NOT NULL");
   }
 }
 


### PR DESCRIPTION
Create a new subclass of SqlArrayValueConstructor, which caters for empty arrays accordingly and registered it against the operator table. So that user can use:
```
SELECT ARRAY[] AS X
FROM Y
```
Tested on affected production views, which could be translated with this patch.

