### PR TITLE
Allows selecting empty map

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlMapValueConstructor.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlMapValueConstructor.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -63,7 +64,7 @@ public class SqlMapValueConstructor extends SqlMultisetValueConstructor {
             callBinding.getScope(),
             callBinding.operands());
     if (argTypes.size() == 0) {
-      throw callBinding.newValidationError(RESOURCE.mapRequiresTwoOrMoreArgs());
+      return true;
     }
     if (argTypes.size() % 2 > 0) {
       throw callBinding.newValidationError(RESOURCE.mapRequiresEvenArgCount());
@@ -83,6 +84,10 @@ public class SqlMapValueConstructor extends SqlMultisetValueConstructor {
   private Pair<RelDataType, RelDataType> getComponentTypes(
       RelDataTypeFactory typeFactory,
       List<RelDataType> argTypes) {
+    if (argTypes.size() == 0) {
+      return Pair.of(typeFactory.createSqlType(SqlTypeName.NULL),
+          typeFactory.createSqlType(SqlTypeName.NULL));
+    }
     return Pair.of(
         typeFactory.leastRestrictive(Util.quotientList(argTypes, 2, 0)),
         typeFactory.leastRestrictive(Util.quotientList(argTypes, 2, 1)));

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -7522,9 +7522,6 @@ public abstract class SqlOperatorBaseTest {
     tester.setFor(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, VM_JAVA);
 
     tester.checkFails(
-        "^Map[]^", "Map requires at least 2 arguments", false);
-
-    tester.checkFails(
         "^Map[1, 'x', 2]^",
         "Map requires an even number of arguments",
         false);

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorTest.java
@@ -43,6 +43,15 @@ public class SqlOperatorTest extends SqlOperatorBaseTest {
     tester.setFor(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR);
     tester.checkScalar("Array[]", "[]", "NULL ARRAY NOT NULL");
   }
+
+  @Test
+  public void testEmptyMap() {
+    tester.setFor(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR);
+    tester.checkScalarExact(
+        "Map[]",
+        "(NULL, NULL) MAP NOT NULL",
+        "[{}]");
+  }
 }
 
 // End SqlOperatorTest.java


### PR DESCRIPTION
Allows users to use:
```
SELECT MAP[] AS X
FROM Y
```
Tests:
1. Tested on affected production views, which could be translated with this patch.
2. Unit test