### PR TITLE
Judge if `node == null` before calling `node.getParserPosition()` in `SqlParserPos.toPos`

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserPos.java
@@ -203,7 +203,7 @@ public class SqlParserPos implements Serializable {
   }
 
   private static Iterable<SqlParserPos> toPos(Iterable<SqlNode> nodes) {
-    return Iterables.transform(nodes, SqlNode::getParserPosition);
+    return Iterables.transform(nodes, node -> node == null ? null : node.getParserPosition());
   }
 
   /**


### PR DESCRIPTION
Previously, if `node == null`, there will be null pointer exception.

Tested on the affected views, could be translated well with this patch.