### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ limitations under the License.
     <junit.version>4.12</junit.version>
     <kafka.client.version>2.1.1</kafka.client.version>
     <kotlin.version>1.2.71</kotlin.version>
-    <log4j2.version>2.11.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>


### PR DESCRIPTION
Hello new Patch!
Update log4j to 2.17.1 to address CVE-2021-44832.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832