### PR TITLE
[Backport] [CALCITE-4090] When generating SQL for DB2, a complex SELECT above a sub-query generates a bad table alias

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1110,6 +1110,7 @@ public abstract class SqlImplementor {
       }
       clauseList.appendAll(clauses);
       Context newContext;
+      Map<String, RelDataType> newAliases = null;
       final SqlNodeList selectList = select.getSelectList();
       if (selectList != null) {
         newContext = new Context(dialect, selectList.size()) {
@@ -1132,7 +1133,7 @@ public abstract class SqlImplementor {
         if (needNew
                 && neededAlias != null
                 && (aliases.size() != 1 || !aliases.containsKey(neededAlias))) {
-          final Map<String, RelDataType> newAliases =
+          newAliases =
               ImmutableMap.of(neededAlias, rel.getInput(0).getRowType());
           newContext = aliasContext(newAliases, qualified);
         } else {
@@ -1140,7 +1141,7 @@ public abstract class SqlImplementor {
         }
       }
       return new Builder(rel, clauseList, select, newContext,
-          needNew ? null : aliases);
+          needNew && !aliases.containsKey(neededAlias) ? newAliases : aliases);
     }
 
     /** Returns whether a new sub-query is required. */

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1677,6 +1677,57 @@ public class RelToSqlConverterTest {
     sql(query).withDb2().ok(expected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4090">[CALCITE-4090]
+   * DB2 aliasing breaks with a complex SELECT above a sub-query</a>. */
+  @Test public void testDb2SubQueryAlias() {
+    String query = "select count(foo), \"units_per_case\"\n"
+        + "from (select \"units_per_case\", \"cases_per_pallet\",\n"
+        + "      \"product_id\", 1 as foo\n"
+        + "  from \"product\")\n"
+        + "where \"cases_per_pallet\" > 100\n"
+        + "group by \"product_id\", \"units_per_case\"\n"
+        + "order by \"units_per_case\" desc";
+    final String expected = "SELECT COUNT(*), t.units_per_case\n"
+        + "FROM (SELECT product.units_per_case, product.cases_per_pallet, "
+        + "product.product_id, 1 AS FOO\n"
+        + "FROM foodmart.product AS product) AS t\n"
+        + "WHERE t.cases_per_pallet > 100\n"
+        + "GROUP BY t.product_id, t.units_per_case\n"
+        + "ORDER BY t.units_per_case DESC";
+    sql(query).withDb2().ok(expected);
+  }
+
+  @Test public void testDb2SubQueryFromUnion() {
+    String query = "select count(foo), \"units_per_case\"\n"
+        + "from (select \"units_per_case\", \"cases_per_pallet\",\n"
+        + "      \"product_id\", 1 as foo\n"
+        + "  from \"product\"\n"
+        + "  where \"cases_per_pallet\" > 100\n"
+        + "  union all\n"
+        + "  select \"units_per_case\", \"cases_per_pallet\",\n"
+        + "      \"product_id\", 1 as foo\n"
+        + "  from \"product\"\n"
+        + "  where \"cases_per_pallet\" < 100)\n"
+        + "where \"cases_per_pallet\" > 100\n"
+        + "group by \"product_id\", \"units_per_case\"\n"
+        + "order by \"units_per_case\" desc";
+    final String expected = "SELECT COUNT(*), t3.units_per_case\n"
+        + "FROM (SELECT product.units_per_case, product.cases_per_pallet, "
+        + "product.product_id, 1 AS FOO\n"
+        + "FROM foodmart.product AS product\n"
+        + "WHERE product.cases_per_pallet > 100\n"
+        + "UNION ALL\n"
+        + "SELECT product0.units_per_case, product0.cases_per_pallet, "
+        + "product0.product_id, 1 AS FOO\n"
+        + "FROM foodmart.product AS product0\n"
+        + "WHERE product0.cases_per_pallet < 100) AS t3\n"
+        + "WHERE t3.cases_per_pallet > 100\n"
+        + "GROUP BY t3.product_id, t3.units_per_case\n"
+        + "ORDER BY t3.units_per_case DESC";
+    sql(query).withDb2().ok(expected);
+  }
+
   @Test public void testDb2DialectSelectQueryWithGroup() {
     String query = "select count(*), sum(\"employee_id\") "
         + "from \"reserve_employee\" "


### PR DESCRIPTION
## Summary
This PR backports the upstream commit https://github.com/apache/calcite/commit/7e557390a08a583e07faf51ee2c8e03829b57b06 for ticket [CALCITE-4090](https://issues.apache.org/jira/browse/CALCITE-4090), which ensures the correct alias for similar Linkedin production views.

Without this modification, the UT
```
@Test void testDb2DialectSubselect() {
  String query = "select count(foo), \"units_per_case\" "
      + "from (select \"units_per_case\", \"cases_per_pallet\", \"product_id\", 1 as foo from \"product\") where \"cases_per_pallet\" > 100 "
      + "group by \"product_id\", \"units_per_case\" "
      + "order by \"units_per_case\" desc";
  final String expected = "SELECT COUNT(*), t.units_per_case\n" +
      "FROM (SELECT product.units_per_case, product.cases_per_pallet, product.product_id, 1 AS " +
      "FOO\n" +
      "FROM foodmart.product AS product) AS t\n" +
      "WHERE t.cases_per_pallet > 100\n" +
      "GROUP BY t.product_id, t.units_per_case\n" +
      "ORDER BY t.units_per_case DESC";
  sql(query).withDb2().ok(expected);
}
```
fails with the "t." alias qualifier in the group by/order by/main select actually being "t0.". 

For LinkedIn use case, we override `hasImplicitTableAlias()` in SqlDialect to `false`. Then for the input SQL
```
SELECT "myTable"."n2"."d" FROM "myTable" WHERE "a" > 5
```
without this PR, the converted SQL is:
```
SELECT \"t0\".\"d\"
FROM (SELECT \"myTable\".\"a\", \"myTable\".\"n1\".\"n11\".\"b\", \"myTable\".\"n1\".\"n12\".\"c\", \"myTable\".\"n2\".\"d\", \"myTable\".\"e\"
FROM \"myDb\".\"myTable\" AS \"myTable\") AS \"t\"
WHERE \"t\".\"a\" > 5
```
which is obviously wrong, but with this PR, the converted SQL is:
```
SELECT \"t\".\"d\"
FROM (SELECT \"myTable\".\"a\", \"myTable\".\"n1\".\"n11\".\"b\", \"myTable\".\"n1\".\"n12\".\"c\", \"myTable\".\"n2\".\"d\", \"myTable\".\"e\"
FROM \"myDb\".\"myTable\" AS \"myTable\") AS \"t\"
WHERE \"t\".\"a\" > 5
```
which is correct.

## Tests
1. New UTs
2. Regression test on production views