### PR TITLE
Backport [CALCITE-4145]: Select nested field from aliased subquery

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1209,6 +1209,10 @@ public abstract class SqlTypeUtil {
    * Returns the ordinal of a given field in a record type, or -1 if the field
    * is not found.
    *
+   * <p>The {@code fieldName} is always simple, if the field is nested within a record field,
+   * returns index of the outer field instead. i.g. for row type
+   * (a int, b (b1 bigint, b2 varchar(20) not null)), returns 1 for both simple name "b1" and "b2".
+   *
    * @param type      Record type
    * @param fieldName Name of field
    * @return Ordinal of field
@@ -1218,6 +1222,10 @@ public abstract class SqlTypeUtil {
     for (int i = 0; i < fields.size(); i++) {
       RelDataTypeField field = fields.get(i);
       if (field.getName().equals(fieldName)) {
+        return i;
+      }
+      final RelDataType fieldType = field.getType();
+      if (fieldType.isStruct() && findField(fieldType, fieldName) != -1) {
         return i;
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3555,6 +3555,21 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4145">[CALCITE-4145]
+   * Exception when nested field queried from subquery</a>.
+   */
+  @Test public void testSelectNestedFromSubquery() {
+//    final String sql = "SELECT deptno, tmp.r.f0, tmp.r.f1 FROM\n"
+//        + "(SELECT deptno, STRUCTURED_FUNC() AS r from dept)tmp";
+//    sql(sql).ok();
+
+    final String sql = "select tmp.nested.\"EXPR$0\" as id from ("
+        + "  select (1, 2) as nested) tmp";
+    sql(sql).ok();
+  }
+
+  /**
    * Visitor that checks that every {@link RelNode} in a tree is valid.
    *
    * @see RelNode#isValid(Litmus, RelNode.Context)

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3560,10 +3560,6 @@ public class SqlToRelConverterTest extends SqlToRelTestBase {
    * Exception when nested field queried from subquery</a>.
    */
   @Test public void testSelectNestedFromSubquery() {
-//    final String sql = "SELECT deptno, tmp.r.f0, tmp.r.f1 FROM\n"
-//        + "(SELECT deptno, STRUCTURED_FUNC() AS r from dept)tmp";
-//    sql(sql).ok();
-
     final String sql = "select tmp.nested.\"EXPR$0\" as id from ("
         + "  select (1, 2) as nested) tmp";
     sql(sql).ok();

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -6272,4 +6272,16 @@ LogicalProject(EXPR$0=[IGNORE NULLS(LEAD($5, 4))], EXPR$1=[LEAD($5, 4) OVER (ORD
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testSelectNestedFromSubquery">
+        <Resource name="sql">
+            <![CDATA[SELECT tmp.nested."EXPR$0" AS if FROM
+(SELECT (1, 2) AS nested) tmp]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+LogicalProject(ID=[ROW(1, 2).EXPR$0])
+  LogicalValues(tuples=[[{ 0 }]])
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
This PR backports the upstream bugfix commit https://github.com/apache/calcite/commit/c52f0e527c86f6a6b18e138310359ac0c72ca529 for [CALCITE-4145]

This code change enables projecting nested fields from an aliased subquery that was previously failing.

Consider table:
`tablea: [b: struct<b1:string>]`

previosly the following SQL could not be translated to RelNode representation:
`SELECT talias.b.b1 AS tmp FROM (SELECT tablea.b FROM tablea) AS talias`

It would fail with Exception:
`Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -1
        at java.util.ArrayList.elementData(ArrayList.java:424)
        at java.util.ArrayList.get(ArrayList.java:437)
        at org.apache.calcite.sql.validate.SelectNamespace.getMonotonicity(SelectNamespace.java:73)
        at org.apache.calcite.sql.SqlIdentifier.getMonotonicity(SqlIdentifier.java:371)
        at org.apache.calcite.sql.SqlCallBinding.getOperandMonotonicity(SqlCallBinding.java:188)
        at org.apache.calcite.sql.SqlAsOperator.getMonotonicity(SqlAsOperator.java:139)
        at org.apache.calcite.sql.SqlCall.getMonotonicity(SqlCall.java:182)
        at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectList(SqlToRelConverter.java:3962)
        at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectImpl(SqlToRelConverter.java:670)
        at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelect(SqlToRelConverter.java:627)
        at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3181)
`

Field `b1` couldn't not be discovered as it is a subfield inside struct `b`. 

now it is successfully translated.

**TESTING:**
Unit Test - `./mvnw test -Dtest=SqlToRelConverterTest#testSelectNestedFromSubquery -Dgpg.skip -Dcheckstyle.skip -f core/pom.xml`
Tested against failing production views