### PR TITLE
Start versioning from 200 and above

### DIFF
--- a/.lipublish/publish.sh
+++ b/.lipublish/publish.sh
@@ -42,8 +42,8 @@ VERSION_PREFIX=$(grep -E "<calciteVersion>(.*)</calciteVersion>" pom.xml | cut -
 APACHE_CALCITE_LAST_COMMIT_HASH=$(grep -E "<calciteCommitHash>(.*)</calciteCommitHash>" pom.xml | cut -d'>' -f2 | cut -d'<' -f1)
 # next, we count the number of commits we have made on top of Apache Calcite since the last sync.
 GIT_COMMIT_COUNT=$(git rev-list --count $APACHE_CALCITE_LAST_COMMIT_HASH..HEAD)
-# next, we create an internal version. 100 is an arbitrary seed
-LI_INTERNAL_VERSION=$(($GIT_COMMIT_COUNT + 100))
+# next, we create an internal version. 200 is an arbitrary seed
+LI_INTERNAL_VERSION=$(($GIT_COMMIT_COUNT + 200))
 # now we can construct a build version
 BUILD_VERSION=${VERSION_PREFIX}.${LI_INTERNAL_VERSION}${DEV_VERSION}
 echo "Current build version: ${BUILD_VERSION}"


### PR DESCRIPTION
In the previous #84 , in order for me to test the GitHub action, I committed many un-squashed commits for debugging purposes and ended up publishing v160. I didn't realize this until I later squashed/dropped those debugging commits. So this will create the problem where if we later merge new prs, it will end up being a smaller version number like v155/v156 etc, which is smaller than 160.

Thus, I think the easiest way to fix is to bump the base magic number in the script to 200, so the later version automatically starts at 2xx onwards which wouldn't cause any issues.