### PR TITLE
Jackson upgrade

### DIFF
--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchAggregate.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchAggregate.java
@@ -137,7 +137,7 @@ public class ElasticsearchAggregate extends Aggregate implements ElasticsearchRe
       }
 
       final ObjectNode aggregation = mapper.createObjectNode();
-      final ObjectNode field = aggregation.with(toElasticAggregate(aggCall));
+      final ObjectNode field = aggregation.withObject("/" + toElasticAggregate(aggCall));
 
       final String name = names.isEmpty() ? ElasticsearchConstants.ID : names.get(0);
       field.put("field", implementor.expressionItemMap.getOrDefault(name, name));

--- a/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
+++ b/elasticsearch/src/main/java/org/apache/calcite/adapter/elasticsearch/ElasticsearchTable.java
@@ -205,13 +205,13 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
     orderedGroupBy.addAll(groupBy);
 
     // construct nested aggregations node(s)
-    ObjectNode parent = query.with(AGGREGATIONS);
+    ObjectNode parent = query.withObject("/" + AGGREGATIONS);
     for (String name: orderedGroupBy) {
       final String aggName = "g_" + name;
       fieldMap.put(aggName, name);
 
-      final ObjectNode section = parent.with(aggName);
-      final ObjectNode terms = section.with("terms");
+      final ObjectNode section = parent.withObject("/" + aggName);
+      final ObjectNode terms = section.withObject("/terms");
       terms.put("field", name);
 
       transport.mapping.missingValueFor(name).ifPresent(m -> {
@@ -225,10 +225,10 @@ public class ElasticsearchTable extends AbstractQueryableTable implements Transl
 
       sort.stream().filter(e -> e.getKey().equals(name)).findAny()
           .ifPresent(s ->
-              terms.with("order")
+              terms.withObject("/order")
                   .put("_key", s.getValue().isDescending() ? "desc" : "asc"));
 
-      parent = section.with(AGGREGATIONS);
+      parent = section.withObject("/" + AGGREGATIONS);
     }
 
     // simple version for queries like "select count(*), max(col1) from table" (no GROUP BY cols)

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/EmbeddedElasticsearchPolicy.java
@@ -114,7 +114,8 @@ class EmbeddedElasticsearchPolicy extends ExternalResource {
 
     ObjectNode mappings = mapper().createObjectNode();
 
-    ObjectNode properties = mappings.with("mappings").with("properties");
+    ObjectNode properties = mappings.withObject("/mappings")
+        .withObject("/properties");
     for (Map.Entry<String, String> entry: mapping.entrySet()) {
       applyMapping(properties, entry.getKey(), entry.getValue());
     }
@@ -139,9 +140,9 @@ class EmbeddedElasticsearchPolicy extends ExternalResource {
     if (index > -1) {
       String prefix  = key.substring(0, index);
       String suffix = key.substring(index + 1, key.length());
-      applyMapping(parent.with(prefix).with("properties"), suffix, type);
+      applyMapping(parent.withObject("/" + prefix).withObject("/properties"), suffix, type);
     } else {
-      parent.with(key).put("type", type);
+      parent.withObject("/" + key).put("type", type);
     }
   }
 

--- a/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/adapter/elasticsearch/ScrollingTest.java
@@ -106,7 +106,7 @@ public class ScrollingTest {
     try (InputStream is = response.getEntity().getContent()) {
       final ObjectNode node = NODE.mapper().readValue(is, ObjectNode.class);
       final String path = "/indices/search/scroll_current";
-      final JsonNode scrollCurrent = node.with("nodes").elements().next().at(path);
+      final JsonNode scrollCurrent = node.get("nodes").elements().next().at(path);
       if (scrollCurrent.isMissingNode()) {
         throw new IllegalStateException("Couldn't find node at " + path);
       }

--- a/elasticsearch/src/test/java/org/apache/calcite/test/ElasticsearchChecker.java
+++ b/elasticsearch/src/test/java/org/apache/calcite/test/ElasticsearchChecker.java
@@ -114,7 +114,7 @@ public class ElasticsearchChecker {
       final String[] names = property.split("\\.");
       ObjectNode copy2 = copy;
       for (int i = 0; i < names.length - 1; i++) {
-        copy2 = copy2.with(names[i]);
+        copy2 = copy2.withObject("/" + names[i]);
       }
       copy2.set(names[names.length - 1], expandDots(node));
     });

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@ limitations under the License.
     <hydromatic-resource.version>0.6</hydromatic-resource.version>
     <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
     <hydromatic-tpcds.version>0.4</hydromatic-tpcds.version>
-    <jackson.version>2.13.2</jackson.version>
-    <jackson-databind.version>2.9.10.8</jackson-databind.version>
+    <jackson.version>2.14.1</jackson.version>
+    <jackson-databind.version>2.14.1</jackson-databind.version>
     <janino.version>3.0.11</janino.version>
     <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     <java-diff.version>1.1.2</java-diff.version>


### PR DESCRIPTION
Upgrading Jackson and Jackson-databind library versions in Calcite due to the CVEs pointed out in https://github.com/linkedin/linkedin-calcite/issues/85 .

Fixing the compilation error in elasticsearch module by backporting code changes from https://github.com/apache/calcite/pull/2966 

Testing Done:
./mvnw clean package -Dgpg.skip -Dcheckstyle.skip -f core/pom.xml

After checking in this PR, I'll integ test it with Coral before upgrading the calcite version in Coral.