### PR TITLE
[Partial Backport] partially backport CALCITE-3823 to make quoteIdent…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -334,14 +334,7 @@ public class SqlDialect {
    * @return Quoted identifier
    */
   public String quoteIdentifier(String val) {
-    if (identifierQuoteString == null) {
-      return val; // quoting is not supported
-    }
-    String val2 =
-        val.replaceAll(
-            identifierEndQuoteString,
-            identifierEscapedQuote);
-    return identifierQuoteString + val2 + identifierEndQuoteString;
+    return quoteIdentifier(new StringBuilder(), val).toString();
   }
 
   /**
@@ -357,18 +350,16 @@ public class SqlDialect {
    * @return The buffer
    */
   public StringBuilder quoteIdentifier(
-      StringBuilder buf,
-      String val) {
+          StringBuilder buf,
+          String val) {
     if (identifierQuoteString == null // quoting is not supported
-        || !identifierNeedsQuote(val)) {
+            || identifierEndQuoteString == null
+            || identifierEscapedQuote == null
+            || !identifierNeedsQuote(val)) {
       buf.append(val);
     } else {
-      String val2 =
-          val.replaceAll(
-              identifierEndQuoteString,
-              identifierEscapedQuote);
       buf.append(identifierQuoteString);
-      buf.append(val2);
+      buf.append(val.replace(identifierEndQuoteString, identifierEscapedQuote));
       buf.append(identifierEndQuoteString);
     }
     return buf;

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -350,12 +350,12 @@ public class SqlDialect {
    * @return The buffer
    */
   public StringBuilder quoteIdentifier(
-          StringBuilder buf,
-          String val) {
+      StringBuilder buf,
+      String val) {
     if (identifierQuoteString == null // quoting is not supported
-            || identifierEndQuoteString == null
-            || identifierEscapedQuote == null
-            || !identifierNeedsQuote(val)) {
+        || identifierEndQuoteString == null
+        || identifierEscapedQuote == null
+        || !identifierNeedsQuote(val)) {
       buf.append(val);
     } else {
       buf.append(identifierQuoteString);


### PR DESCRIPTION
…ifier use identifierNeedsQuote()

Before this patch, the `public String quoteIdentifier(String val)` and `public StringBuilder quoteIdentifier(StringBuilder buf, String val)` has 2 versions of implementations where the latter uses a `identifierNeedsQuote` but the first doesn't. The `identifierNeedsQuote` is a good interface method which could be overriden by custom dialect impls to selectively decide quoting identifiers.

This patch updates the first to call the second to remove the double implementation, which is also the latest code in oss calcite: https://github.com/apache/calcite/commit/4208d0ba6f2a749692fe64181a1373af07d55db5#diff-f2520e36fa89c1212763ae598e213eb9d9006cc392136b5557a40e3cbdb56760 

Since back porting that entire PR requires a lot of patches. I just includes this local fix so that Coral can utilize the `identifierNeedsQuote` after this patch.

build and test succeeds with `mvn package`