### PR TITLE
Preserve LATERAL keyword during validation

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -66,8 +67,16 @@ public class AliasNamespace extends AbstractNamespace {
   protected RelDataType validateImpl(RelDataType targetRowType) {
     final List<String> nameList = new ArrayList<>();
     final List<SqlNode> operands = call.getOperandList();
-    final SqlValidatorNamespace childNs =
-        validator.getNamespace(operands.get(0));
+    final SqlValidatorNamespace childNs;
+
+    if (operands.get(0).getKind() == SqlKind.LATERAL) {
+      childNs =
+          validator.getNamespace(((SqlCall) operands.get(0)).operand(0));
+    } else {
+      childNs  =
+          validator.getNamespace(operands.get(0));
+    }
+
     final RelDataType rowType = childNs.getRowTypeSansSystemColumns();
     final List<SqlNode> columnNames = Util.skip(operands, 2);
     for (final SqlNode operand : columnNames) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/AliasNamespace.java
@@ -68,15 +68,13 @@ public class AliasNamespace extends AbstractNamespace {
     final List<String> nameList = new ArrayList<>();
     final List<SqlNode> operands = call.getOperandList();
     final SqlValidatorNamespace childNs;
-
+    // Skip over fetching for LATERAL namespace since they are not registered, use subquery instead
     if (operands.get(0).getKind() == SqlKind.LATERAL) {
-      childNs =
-          validator.getNamespace(((SqlCall) operands.get(0)).operand(0));
+      SqlNode lateral = operands.get(0);
+      childNs = validator.getNamespace(((SqlCall) lateral).operand(0));
     } else {
-      childNs  =
-          validator.getNamespace(operands.get(0));
+      childNs = validator.getNamespace(operands.get(0));
     }
-
     final RelDataType rowType = childNs.getRowTypeSansSystemColumns();
     final List<SqlNode> columnNames = Util.skip(operands, 2);
     for (final SqlNode operand : columnNames) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/JoinNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/JoinNamespace.java
@@ -18,7 +18,9 @@ package org.apache.calcite.sql.validate;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 
 /**
@@ -39,10 +41,24 @@ class JoinNamespace extends AbstractNamespace {
   //~ Methods ----------------------------------------------------------------
 
   protected RelDataType validateImpl(RelDataType targetRowType) {
+    SqlNode left;
+    if (join.getLeft().getKind() == SqlKind.LATERAL) {
+      left = ((SqlCall) join.getLeft()).operand(0);
+    } else {
+      left = join.getLeft();
+    }
     RelDataType leftType =
-        validator.getNamespace(join.getLeft()).getRowType();
+        validator.getNamespace(left).getRowType();
+
+    SqlNode right;
+    if (join.getRight().getKind() == SqlKind.LATERAL) {
+      right = ((SqlCall) join.getRight()).operand(0);
+    } else {
+      right = join.getRight();
+    }
+
     RelDataType rightType =
-        validator.getNamespace(join.getRight()).getRowType();
+        validator.getNamespace(right).getRowType();
     final RelDataTypeFactory typeFactory = validator.getTypeFactory();
     switch (join.getJoinType()) {
     case LEFT:

--- a/core/src/main/java/org/apache/calcite/sql/validate/JoinNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/JoinNamespace.java
@@ -41,17 +41,14 @@ class JoinNamespace extends AbstractNamespace {
   //~ Methods ----------------------------------------------------------------
 
   protected RelDataType validateImpl(RelDataType targetRowType) {
-    SqlNode left;
-    if (join.getLeft().getKind() == SqlKind.LATERAL) {
-      left = ((SqlCall) join.getLeft()).operand(0);
-    } else {
-      left = join.getLeft();
-    }
     RelDataType leftType =
-        validator.getNamespace(left).getRowType();
+        validator.getNamespace(join.getLeft()).getRowType();
 
+    // Since LATERALS are used preceding subqueries appearing in FROM to allow the subquery to
+    // reference columns provided by preceding FROM items, LATERALS will only appear on the right side of a join.
     SqlNode right;
     if (join.getRight().getKind() == SqlKind.LATERAL) {
+      // Skip over fetching for LATERAL's name space since they are not registered
       right = ((SqlCall) join.getRight()).operand(0);
     } else {
       right = join.getRight();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1115,6 +1115,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       }
       // fall through
     case SNAPSHOT:
+    case LATERAL:
     case OVER:
     case COLLECTION_TABLE:
     case ORDER_BY:
@@ -2209,7 +2210,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
               null,
               null,
               forceRightNullable,
-//              rightIsLateral,
               lateral);
       if (newRight != right) {
         join.setRight(newRight);
@@ -2237,35 +2237,16 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       return newNode;
 
     case LATERAL:
-      SqlNode sqlNode1 = registerFrom(
+      return registerFrom(
           parentScope,
           usingScope,
           register,
-          ((SqlCall) node).operand(0), // this is where the drop actually happens since node is the lateral call and it's first operand is simply the inner subquery. I've attempted to simply pass in "node" here but leads to infinite recursion.
+          ((SqlCall) node).operand(0),
           enclosingNode,
           alias,
           extendList,
           forceNullable,
           true);
-      return sqlNode1;
-//      call = (SqlCall) node;
-//      operand = call.operand(0);
-//      newOperand =
-//          registerFrom(
-//              parentScope,
-//              usingScope,
-//              register,
-//              operand, // this is where the drop actually happens since node is the lateral call and it's first operand is simply the inner subquery. I've attempted to simply pass in "node" here but leads to infinite recursion.
-//              enclosingNode,
-//              alias,
-//              extendList,
-//              forceNullable,
-//              true);
-//      if (newOperand != operand) {
-//        call.setOperand(0, newOperand);
-//      }
-//      scopes.put(node, parentScope);
-//      return node;
 
     case COLLECTION_TABLE:
       call = (SqlCall) node;

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2237,7 +2237,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
           parentScope,
           usingScope,
           register,
-          ((SqlCall) node).operand(0), // this is where the drop actually happens since node is the lateral call and it's first operand is simply the inner subquery
+          ((SqlCall) node).operand(0), // this is where the drop actually happens since node is the lateral call and it's first operand is simply the inner subquery. I've attempted to simply pass in "node" here but leads to infinite recursion.
           enclosingNode,
           alias,
           extendList,

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2087,9 +2087,14 @@ public class SqlToRelConverter {
       if (left.getKind() == SqlKind.LATERAL) {
         left = ((SqlCall) left).operand(0);
       }
+      else if ((left.getKind() == SqlKind.AS && ((SqlCall) left).operand(0).getKind() == SqlKind.LATERAL)) {
+        left = ((SqlCall)((SqlCall) left).operand(0)).operand(0);
+      }
       convertFrom(leftBlackboard, left);
       RelNode leftRel = leftBlackboard.root;
-      if (right.getKind() == SqlKind.LATERAL || (right.getKind() == SqlKind.AS && ((SqlCall) right).operand(0).getKind() == SqlKind.LATERAL)) {
+      if (right.getKind() == SqlKind.LATERAL) {
+        right = ((SqlCall) right).operand(0);
+      } else if ((right.getKind() == SqlKind.AS && ((SqlCall) right).operand(0).getKind() == SqlKind.LATERAL)) {
         right = ((SqlCall)((SqlCall) right).operand(0)).operand(0);
       }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1993,6 +1993,7 @@ public class SqlToRelConverter {
       return;
     }
 
+    // Skip over LATERAL conversion
     if (from.getKind() == SqlKind.LATERAL) {
       from = ((SqlCall) from).operand(0);
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2084,20 +2084,8 @@ public class SqlToRelConverter {
               ((DelegatingScope) bb.scope).getParent());
       final Blackboard rightBlackboard =
           createBlackboard(rightScope, null, false);
-      if (left.getKind() == SqlKind.LATERAL) {
-        left = ((SqlCall) left).operand(0);
-      }
-      else if ((left.getKind() == SqlKind.AS && ((SqlCall) left).operand(0).getKind() == SqlKind.LATERAL)) {
-        left = ((SqlCall)((SqlCall) left).operand(0)).operand(0);
-      }
       convertFrom(leftBlackboard, left);
       RelNode leftRel = leftBlackboard.root;
-      if (right.getKind() == SqlKind.LATERAL) {
-        right = ((SqlCall) right).operand(0);
-      } else if ((right.getKind() == SqlKind.AS && ((SqlCall) right).operand(0).getKind() == SqlKind.LATERAL)) {
-        right = ((SqlCall)((SqlCall) right).operand(0)).operand(0);
-      }
-
       convertFrom(rightBlackboard, right);
       RelNode rightRel = rightBlackboard.root;
       JoinRelType convertedJoinType = convertJoinType(joinType);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1993,6 +1993,10 @@ public class SqlToRelConverter {
       return;
     }
 
+    if (from.getKind() == SqlKind.LATERAL) {
+      from = ((SqlCall) from).operand(0);
+    }
+
     final SqlCall call;
     final SqlNode[] operands;
     switch (from.getKind()) {
@@ -2080,8 +2084,15 @@ public class SqlToRelConverter {
               ((DelegatingScope) bb.scope).getParent());
       final Blackboard rightBlackboard =
           createBlackboard(rightScope, null, false);
+      if (left.getKind() == SqlKind.LATERAL) {
+        left = ((SqlCall) left).operand(0);
+      }
       convertFrom(leftBlackboard, left);
       RelNode leftRel = leftBlackboard.root;
+      if (right.getKind() == SqlKind.LATERAL || (right.getKind() == SqlKind.AS && ((SqlCall) right).operand(0).getKind() == SqlKind.LATERAL)) {
+        right = ((SqlCall)((SqlCall) right).operand(0)).operand(0);
+      }
+
       convertFrom(rightBlackboard, right);
       RelNode rightRel = rightBlackboard.root;
       JoinRelType convertedJoinType = convertJoinType(joinType);


### PR DESCRIPTION
Summary

`LATERALS` are dropped when validating a SqlNode. This is a [known behavior](https://issues.apache.org/jira/browse/CALCITE-4039) that Calcite doesn't consider a bug. 

However, in the process of migrating to [Coral IR V2](https://docs.google.com/document/d/1UC9NcVPZLjHNfyyiU7G_LzxAiylnj7T8i9Nr3heXxbs/edit), we use Calcite`validate` more than before causing LATERALs to be dropped when they were not before. The dropping of these LATERALs are semantically incorrect (since we want language specific SqlNodes and not Calcite SqlNode) as confirmed by running the translated sql texts in the respective language engine without LATERAL and watching them fail. Therefore we want to preserve these LATERALS.

Please note that this PR is simply keeping a LATERAL if it is ever dropped and then skipping over it as if it was never added back.

Testing

- `./mvnw clean package -Dgpg.skip -Dcheckstyle.skip -f core/pom.xml`
   all unit tests are passing
- Coral unit tests pass with these changes
- Still need to i-test these calcite changes in Coral [update, tests passed https://github.com/linkedin/coral/pull/491]