### PR TITLE
Preserve LATERAL UNNEST during SqlNode validation

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.BarfingInvocationHandler;
@@ -1077,6 +1078,17 @@ public abstract class SqlUtil {
 
     @Override public Void visit(SqlDataTypeSpec type) {
       return check(type);
+    }
+  }
+
+  /** Walks over a {@link org.apache.calcite.sql.SqlNode} tree and removes any
+   * instance of a LATERAL operator. */
+  public static class LateralRemover extends SqlShuttle {
+    @Override public SqlNode visit(SqlCall call) {
+      if (call.getKind() == SqlKind.LATERAL) {
+        return call.operand(0).accept(this);
+      }
+      return super.visit(call);
     }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2298,7 +2298,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       //    Example: SELECT ... FROM LATERAL(SELECT ...) AS t
       // 2. Joins with UNNEST operator preceded by LATERAL
       //    Example: SELECT ... FROM LATERAL(UNNEST ...) AS t
-      if (lateral && (kind == SqlKind.SELECT) || (kind == SqlKind.UNNEST)) {
+      if (lateral && (kind == SqlKind.SELECT || kind == SqlKind.UNNEST)) {
         SqlNode lateralNode =
             SqlStdOperatorTable.LATERAL.createCall(POS, newNode);
         return lateralNode;

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11533,21 +11533,21 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   @Test
-  public void testLateralPreservedInLateralUnnest() throws SqlParseException {
+  public void testLateralKeywordIsNotAddedToUnnest() throws SqlParseException {
     // Per SQL std, UNNEST is implicitly LATERAL
     String sql = "select*from unnest(array[1])";
     SqlNode node = tester.parseQuery(sql);
     SqlValidator validator = tester.getValidator();
     SqlNode validatedNode = validator.validate(node);
 
-    assertTrue(validatedNode.toString().contains("LATERAL"));
+    assertTrue(!validatedNode.toString().contains("LATERAL"));
 
     sql = "select c from unnest(array(select deptno from dept)) as t(c)";
     node = tester.parseQuery(sql);
     validator = tester.getValidator();
     validatedNode = validator.validate(node);
 
-    assertTrue(validatedNode.toString().contains("LATERAL"));
+    assertTrue(!validatedNode.toString().contains("LATERAL"));
   }
 }
 


### PR DESCRIPTION
**Summary**

This is a follow up to #98, where LATERALs were only preserved during validation if they appeared in the form `... LATERAL (SELECT ....`. This PR induces the preservation behavior also in the `.. LATERAL (UNNEST ...` case, this is needed for Coral to produce correct translations on views (see [CoralSqlNodeToSparkSqlNodeConverter](https://github.com/linkedin/coral/blob/master/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSqlNodeToSparkSqlNodeConverter.java) for details).

**Testing**
- new unit test to test that this only a preservation mechanism, we never add LATERALs that were never there to begin with
   - note that we cannot write a LATERAL UNNEST test case here in Calcite since it will not parse, see [here](https://github.com/linkedin/linkedin-calcite/blob/c10eb657eeb72673ad2d2ebe6ed959ce6aaee555/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java#L7405). Instead we will use an acompanying Coral unit test that will generate the LATERAL UNNEST sqlnode case we need to test
- new unit test in coral with these changes: https://github.com/linkedin/coral/pull/542
- mvn clean build (also runs all unit tests) `./mvnw clean install -Dgpg.skip -f core/pom.xml`
- clean build in coral with these changes `./gradlew clean build`
- correct translation with these changes for production view text which was previously incorrect 
- regression testing on all production views [pending]