### PR TITLE
Use Sonatype token username and token password

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,14 +22,14 @@ jobs:
       with:
         ref: 'li-1.21.0'
         fetch-depth: 0
-    
+
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
         java-version: '8'
         distribution: 'temurin'
         server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
-        
+
     - name: Import GPG key
       id: import_gpg
       uses: crazy-max/ghaction-import-gpg@v5
@@ -42,6 +42,6 @@ jobs:
         chmod +x .lipublish/publish.sh
         .lipublish/publish.sh
       env:
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+        SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         GPG_PASSWD: ${{ secrets.GPG_PASSWD }}

--- a/.lipublish/publish.sh
+++ b/.lipublish/publish.sh
@@ -17,13 +17,13 @@
 
 echo "!!This will change the pom.xml files and you will need to revert them. If you have local changes, exit now and stash them!!"
 
-while [ -z "$SONATYPE_USERNAME" ]; do
+while [ -z "$SONATYPE_TOKEN_USERNAME" ]; do
   echo "Please provide your sonatype username"
-  read SONATYPE_USERNAME
+  read SONATYPE_TOKEN_USERNAME
 done
-while [ -z "$SONATYPE_PASSWORD" ]; do
+while [ -z "$SONATYPE_TOKEN_PASSWORD" ]; do
   echo "Please provide your sonatype password"
-  read SONATYPE_PASSWORD
+  read SONATYPE_TOKEN_PASSWORD
   echo
 done
 while [ -z "$GPG_PASSWD" ]; do
@@ -52,4 +52,4 @@ mvn versions:set -DnewVersion="$BUILD_VERSION" -q -B
 mvn versions:commit -q -B
 
 echo "Publishing to maven central"
-MVN_DEPLOY_SONATYPE_USER=$SONATYPE_USERNAME MVN_DEPLOY_SONATYPE_PASSWORD=$SONATYPE_PASSWORD MVN_DEPLOY_GPG_PASSWD=$GPG_PASSWD eval 'mvn clean deploy -s .lipublish/publishSettings.xml -DskipTests -q -DretryFailedDeploymentCount=5'
+MVN_DEPLOY_SONATYPE_TOKEN_USERNAME=$SONATYPE_TOKEN_USERNAME MVN_DEPLOY_SONATYPE_TOKEN_PASSWORD=$SONATYPE_TOKEN_PASSWORD MVN_DEPLOY_GPG_PASSWD=$GPG_PASSWD eval 'mvn clean deploy -s .lipublish/publishSettings.xml -DskipTests -q -DretryFailedDeploymentCount=5'

--- a/.lipublish/publish.sh
+++ b/.lipublish/publish.sh
@@ -18,11 +18,11 @@
 echo "!!This will change the pom.xml files and you will need to revert them. If you have local changes, exit now and stash them!!"
 
 while [ -z "$SONATYPE_TOKEN_USERNAME" ]; do
-  echo "Please provide your sonatype username"
+  echo "Please provide your sonatype token username"
   read SONATYPE_TOKEN_USERNAME
 done
 while [ -z "$SONATYPE_TOKEN_PASSWORD" ]; do
-  echo "Please provide your sonatype password"
+  echo "Please provide your sonatype token password"
   read SONATYPE_TOKEN_PASSWORD
   echo
 done

--- a/.lipublish/publishSettings.xml
+++ b/.lipublish/publishSettings.xml
@@ -19,8 +19,8 @@ limitations under the License.
   <servers>
     <server>
       <id>ossrh</id>
-      <username>${env.MVN_DEPLOY_SONATYPE_USER}</username>
-      <password>${env.MVN_DEPLOY_SONATYPE_PASSWORD}</password>
+      <username>${env.MVN_DEPLOY_SONATYPE_TOKEN_USERNAME}</username>
+      <password>${env.MVN_DEPLOY_SONATYPE_TOKEN_PASSWORD}</password>
     </server>
   </servers>
   <profiles>


### PR DESCRIPTION
### Summary
What changes are proposed in this pull request, and why are they necessary?
We currently use the Nexus UI sonatype username and password for maven release, which doesn't work now due to the recent maven central migration. This leads to errors like this during publishing to maven in GHA, [example failure](https://github.com/linkedin/linkedin-calcite/actions/runs/11690200841/job/32612582255#step:5:92):
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) on project calcite-kafka: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy failed: Nexus connection problem to URL [https://oss.sonatype.org/ ]: 401 - Unauthorized -> [Help 1]
```

This PR modifies the publishing configs to use the newly added github repo secrets SONATYPE_TOKEN_USERNAME and SONATYPE_TOKEN_PASSWORD.

### Testing
`./mvnw clean install -Dgpg.skip -f core/pom.xml` succeeds