### PR TITLE
Revert 2.0.0 major version bump

### DIFF
--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-babel</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Babel</name>
   <description>Calcite Babel</description>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -532,7 +532,7 @@ limitations under the License.
                 </filter>
               </filters>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded-all</shadedClassifierName>
+              <shadedClassifierName>shaded</shadedClassifierName>
             </configuration>
           </execution>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <licenses>
@@ -33,7 +33,7 @@ limitations under the License.
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -752,7 +752,7 @@ public class JdbcTest {
     final String driverVersion = metaData.getDriverVersion();
     final int driverMajor = metaData.getDriverMajorVersion();
     final int driverMinor = metaData.getDriverMinorVersion();
-    assertEquals(2, driverMajor);
+    assertEquals(1, driverMajor);
     assertTrue(driverMinor >= 0 && driverMinor < 30);
 
     assertEquals("Calcite", metaData.getDatabaseProductName());
@@ -779,7 +779,7 @@ public class JdbcTest {
         || driverVersion.endsWith("-SNAPSHOT")
             && driverVersion.startsWith(mm(driverMajor, driverMinor + 1)));
 
-    assertTrue(databaseVersion.startsWith("2."));
+    assertTrue(databaseVersion.startsWith("1."));
     assertTrue(databaseVersion.split("\\.").length >= 2);
     assertTrue(databaseVersion.equals(mm(databaseMajor, databaseMinor))
         || databaseVersion.startsWith(mm(databaseMajor, databaseMinor) + ".")

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <!-- The basics. -->

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@ limitations under the License.
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <top.dir>${project.basedir}</top.dir>
-    <version.major>2</version.major>
-    <version.minor>0</version.minor>
+    <version.major>1</version.major>
+    <version.minor>21</version.minor>
 
     <!-- Don't fail the build for vulnerabilities below this threshold. -->
     <failBuildOnCVSS>8</failBuildOnCVSS>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>com.linkedin.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
 
   <licenses>
     <license>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>1.21.0.140</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.linkedin.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>2.0.0</version>
+    <version>1.21.0.140</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
- revert major version bump as we are still on branch 1.21.0, determined the shading package change is safe to do so without one
- fix classifier for `shaded` package
- tested using ` ./mvnw clean install -Dgpg.skip -f core/pom.xml`