### PR TITLE
Fix release to use Central Publisher Portal since OSSRH sunset

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         java-version: '8'
         distribution: 'temurin'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
 
     - name: Import GPG key
       id: import_gpg

--- a/.lipublish/publishSettings.xml
+++ b/.lipublish/publishSettings.xml
@@ -18,14 +18,14 @@ limitations under the License.
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.MVN_DEPLOY_SONATYPE_TOKEN_USERNAME}</username>
       <password>${env.MVN_DEPLOY_SONATYPE_TOKEN_PASSWORD}</password>
     </server>
   </servers>
   <profiles>
     <profile>
-      <id>ossrh</id>
+      <id>central</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -641,15 +641,18 @@ limitations under the License.
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>


### PR DESCRIPTION
Fix the release process using https://central.sonatype.org/publish/publish-portal-maven/ plugin. The previous OSSRH is sunset per: https://central.sonatype.org/pages/ossrh-eol/ and we can't publish to it anymore.